### PR TITLE
Remove InternalTraceLevel setting; fixes #20

### DIFF
--- a/src/TestCentric/testcentric.gui/AppEntry.cs
+++ b/src/TestCentric/testcentric.gui/AppEntry.cs
@@ -66,10 +66,13 @@ namespace TestCentric.Gui
                 return 2;
             }
 
-            var traceLevel = options.InternalTraceLevel != null
-                ? (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), options.InternalTraceLevel)
-                : InternalTraceLevel.Off;
+            // Currently the InternalTraceLevel can only be set from the command-line.
+            // We can't use user settings to provide a default because the settings
+            // are an engine service and the engine have the internal trace level
+            // set as part of its initialization.
+            var traceLevel = options.InternalTraceLevel;
 
+            // This initializes the trace setting for the GUI itself.
             InternalTrace.Initialize($"InternalTrace.{Process.GetCurrentProcess().Id}.gui.log", traceLevel);
             log.Info($"Starting TestCentric Runner - InternalTraceLevel = {traceLevel}");
 

--- a/src/TestCentric/testcentric.gui/CommandLineOptions.cs
+++ b/src/TestCentric/testcentric.gui/CommandLineOptions.cs
@@ -24,8 +24,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using Mono.Options;
+using NUnit.Engine;
 
 namespace TestCentric.Gui
 {
@@ -77,7 +77,11 @@ namespace TestCentric.Gui
             //    v => RunSelectedTests = v != null);
 
             this.Add("trace=", "Set internal trace {LEVEL}.",
-                v => InternalTraceLevel = RequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"));
+                v =>
+                {
+                    var traceSetting = RequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug");
+                    InternalTraceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), v);
+                });
 
             this.Add("help|h", "Display this message and exit.", 
                 v => ShowHelp = v != null);
@@ -124,7 +128,7 @@ namespace TestCentric.Gui
 
         // Output GuiElement
 
-        public string InternalTraceLevel { get; private set; }
+        public InternalTraceLevel InternalTraceLevel { get; private set; }
 
         // Error Processing
 

--- a/src/TestCentric/testcentric.gui/SettingsPages/AdvancedLoaderSettingsPage.cs
+++ b/src/TestCentric/testcentric.gui/SettingsPages/AdvancedLoaderSettingsPage.cs
@@ -22,12 +22,8 @@
 // ***********************************************************************
 
 using System;
-using System.Collections;
-using System.ComponentModel;
-using System.Drawing;
 using System.Security.Principal;
 using System.Windows.Forms;
-using NUnit.Engine;
 
 namespace TestCentric.Gui.SettingsPages
 {
@@ -44,10 +40,6 @@ namespace TestCentric.Gui.SettingsPages
         private GroupBox groupBox1;
         private ListBox principalPolicyListBox;
         private Label label1;
-        private ComboBox traceLevelComboBox;
-        private Label label4;
-        private Label label5;
-        private GroupBox groupBox2;
         private System.ComponentModel.IContainer components = null;
 
 		public AdvancedLoaderSettingsPage( string key ) : base( key )
@@ -92,10 +84,6 @@ namespace TestCentric.Gui.SettingsPages
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.principalPolicyListBox = new System.Windows.Forms.ListBox();
             this.label1 = new System.Windows.Forms.Label();
-            this.traceLevelComboBox = new System.Windows.Forms.ComboBox();
-            this.label4 = new System.Windows.Forms.Label();
-            this.label5 = new System.Windows.Forms.Label();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.SuspendLayout();
             // 
             // label3
@@ -134,8 +122,8 @@ namespace TestCentric.Gui.SettingsPages
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(260, 59);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Shadow copy should normally be enabled. If it is disabled, the TestCentric Gui may not " +
-    "function correctly.";
+            this.label2.Text = "Shadow copy should normally be enabled. If it is disabled, the TestCentric Gui ma" +
+    "y not function correctly.";
             // 
             // principalPolicyCheckBox
             // 
@@ -197,55 +185,8 @@ namespace TestCentric.Gui.SettingsPages
             this.label1.TabIndex = 12;
             this.label1.Text = "Warning:";
             // 
-            // traceLevelComboBox
-            // 
-            this.traceLevelComboBox.FormattingEnabled = true;
-            this.traceLevelComboBox.Items.AddRange(new object[] {
-            "Default",
-            "Off",
-            "Error",
-            "Warning",
-            "Info",
-            "Verbose"});
-            this.traceLevelComboBox.Location = new System.Drawing.Point(137, 298);
-            this.traceLevelComboBox.Name = "traceLevelComboBox";
-            this.traceLevelComboBox.Size = new System.Drawing.Size(89, 21);
-            this.traceLevelComboBox.TabIndex = 20;
-            // 
-            // label4
-            // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(22, 301);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(67, 13);
-            this.label4.TabIndex = 19;
-            this.label4.Text = "Trace Level:";
-            // 
-            // label5
-            // 
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(12, 267);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(73, 13);
-            this.label5.TabIndex = 18;
-            this.label5.Text = "Internal Trace";
-            // 
-            // groupBox2
-            // 
-            this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox2.Location = new System.Drawing.Point(139, 267);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(309, 8);
-            this.groupBox2.TabIndex = 17;
-            this.groupBox2.TabStop = false;
-            // 
             // AdvancedLoaderSettingsPage
             // 
-            this.Controls.Add(this.traceLevelComboBox);
-            this.Controls.Add(this.label4);
-            this.Controls.Add(this.label5);
-            this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.principalPolicyListBox);
             this.Controls.Add(this.principalPolicyCheckBox);
@@ -270,8 +211,6 @@ namespace TestCentric.Gui.SettingsPages
             principalPolicyCheckBox.Checked = principalPolicyListBox.Enabled =
                 Settings.GetSetting("Options.TestLoader.SetPrincipalPolicy", false);
             principalPolicyListBox.SelectedIndex = (int)(PrincipalPolicy)Settings.GetSetting("Options.TestLoader.PrincipalPolicy", PrincipalPolicy.UnauthenticatedPrincipal);
-
-            traceLevelComboBox.SelectedIndex = (int)(InternalTraceLevel)Settings.GetSetting("Options.InternalTraceLevel", InternalTraceLevel.Default);
         }
 
         public override void ApplySettings()
@@ -284,10 +223,6 @@ namespace TestCentric.Gui.SettingsPages
                 Settings.SaveSetting("Options.TestLoader.PrincipalPolicy", (PrincipalPolicy)principalPolicyListBox.SelectedIndex);
             else
                 Settings.RemoveSetting("Options.TestLoader.PrincipalPolicy");
-
-            InternalTraceLevel level = (InternalTraceLevel)traceLevelComboBox.SelectedIndex;
-            Settings.SaveSetting("Options.InternalTraceLevel", level);
-            //InternalTrace.Level = level;
         }
 
         public override bool HasChangesRequiringReload

--- a/src/TestCentric/testcentric.gui/SettingsPages/AdvancedLoaderSettingsPage.resx
+++ b/src/TestCentric/testcentric.gui/SettingsPages/AdvancedLoaderSettingsPage.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="helpProvider1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="helpProvider1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <data name="disableShadowCopyCheckBox.HelpString" xml:space="preserve">

--- a/src/TestModel/model/TestModel.cs
+++ b/src/TestModel/model/TestModel.cs
@@ -351,7 +351,6 @@ namespace TestCentric.Gui.Model
 
             // Temp settings for testing
             package.AddSetting(EnginePackageSettings.ProcessModel, "Single");
-            package.AddSetting(EnginePackageSettings.InternalTraceLevel, "Debug");
 
             foreach (var entry in PackageSettings)
                 package.AddSetting(entry.Key, entry.Value);


### PR DESCRIPTION
This change simply acknowledges the fact that it's not currently possible to use the settings managed by the engine to set the trace level for the engine. We will use only the command-line `--trace` option for this purpose until something changes.